### PR TITLE
fix: group majority@k and reward@k by answer string (#1257)

### DIFF
--- a/nemo_skills/evaluation/metrics/base.py
+++ b/nemo_skills/evaluation/metrics/base.py
@@ -14,7 +14,7 @@
 
 import abc
 import math
-from collections import Counter, defaultdict
+from collections import defaultdict
 
 import numpy as np
 
@@ -275,17 +275,26 @@ class BaseMetrics(abc.ABC):
                     majority_score = 0
                     majority_answer = None
                 else:
-                    # Find the most common answer and its correctness
-                    majority_count = Counter(valid_answers_and_results).most_common(1)[0][1]
-                    majority_answer_list = [
-                        (answer, score)
-                        for (answer, score), count in Counter(valid_answers_and_results).items()
-                        if count == majority_count
-                    ]
-                    # Majority score is the average of the scores of the most common answers
-                    majority_score = sum(score for answer, score in majority_answer_list) / len(majority_answer_list)
+                    # Vote on the answer alone. A non-deterministic judge can score the
+                    # same answer differently across generations, and those are repeated
+                    # votes for one answer rather than votes for several.
+                    answer_verdicts = defaultdict(list)
+                    for answer, score in valid_answers_and_results:
+                        answer_verdicts[answer].append(score)
+
+                    majority_count = max(len(verdicts) for verdicts in answer_verdicts.values())
                     # Choose a deterministic answer from the most common answers for reproducibility
-                    majority_answer = sorted(majority_answer_list)[0][0]
+                    majority_answers = sorted(
+                        answer for answer, verdicts in answer_verdicts.items() if len(verdicts) == majority_count
+                    )
+                    # Average the verdicts within an answer first, then average across
+                    # the most common answers as before, so a judge that disagreed with
+                    # itself lands between the two verdicts instead of picking one.
+                    majority_score = sum(
+                        sum(answer_verdicts[answer]) / len(answer_verdicts[answer]) for answer in majority_answers
+                    )
+                    majority_score /= len(majority_answers)
+                    majority_answer = majority_answers[0]
 
                 eval_dict[f"majority@{k}"][score_method] += majority_score
 

--- a/nemo_skills/evaluation/metrics/math_metrics.py
+++ b/nemo_skills/evaluation/metrics/math_metrics.py
@@ -52,15 +52,19 @@ class MathMetrics(BaseMetrics):
                     self.eval_dict[f"rm_best@{k}"][score_method] += is_correct_best
 
                     answer_to_score_dict = defaultdict(float)
-                    answer_to_correctness_dict = {}
+                    # Keep every verdict for an answer rather than the last one: a
+                    # non-deterministic judge can score the same answer both ways, and
+                    # plain assignment would let generation order decide the result.
+                    answer_to_verdicts = defaultdict(list)
                     for predicted_answer, is_correct, reward_score in valid_answers_and_results:
                         answer_to_score_dict[predicted_answer] += reward_score
-                        answer_to_correctness_dict[predicted_answer] = is_correct
+                        answer_to_verdicts[predicted_answer].append(is_correct)
 
                     top_cum_reward_answer = sorted(
                         list(answer_to_score_dict.items()), key=lambda x: x[1], reverse=True
                     )[0][0]
-                    is_correct_majority = answer_to_correctness_dict[top_cum_reward_answer]
+                    top_answer_verdicts = answer_to_verdicts[top_cum_reward_answer]
+                    is_correct_majority = sum(top_answer_verdicts) / len(top_answer_verdicts)
                     self.eval_dict[f"rm_majority@{k}"][score_method] += is_correct_majority
 
             no_answer = all(elem[self.answer_key] is None for elem in predictions[:k])

--- a/nemo_skills/evaluation/metrics/omni_metrics.py
+++ b/nemo_skills/evaluation/metrics/omni_metrics.py
@@ -43,15 +43,19 @@ class OmniMetrics(BaseMetrics):
                     self.eval_dict[f"rm_best@{k}"][score_method] += is_correct_best
 
                     answer_to_score_dict = defaultdict(float)
-                    answer_to_correctness_dict = {}
+                    # Keep every verdict for an answer rather than the last one: a
+                    # non-deterministic judge can score the same answer both ways, and
+                    # plain assignment would let generation order decide the result.
+                    answer_to_verdicts = defaultdict(list)
                     for predicted_answer, is_correct, reward_score in valid_answers_and_results:
                         answer_to_score_dict[predicted_answer] += reward_score
-                        answer_to_correctness_dict[predicted_answer] = is_correct
+                        answer_to_verdicts[predicted_answer].append(is_correct)
 
                     top_cum_reward_answer = sorted(
                         list(answer_to_score_dict.items()), key=lambda x: x[1], reverse=True
                     )[0][0]
-                    is_correct_majority = answer_to_correctness_dict[top_cum_reward_answer]
+                    top_answer_verdicts = answer_to_verdicts[top_cum_reward_answer]
+                    is_correct_majority = sum(top_answer_verdicts) / len(top_answer_verdicts)
                     self.eval_dict[f"rm_majority@{k}"][score_method] += is_correct_majority
 
             no_answer = all(elem[self.answer_key] is None for elem in predictions[:k])

--- a/nemo_skills/evaluation/metrics/weighted_math_metrics.py
+++ b/nemo_skills/evaluation/metrics/weighted_math_metrics.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from collections import Counter, defaultdict
+from collections import defaultdict
 
 import numpy as np
 
@@ -61,10 +61,17 @@ class WeightedMathMetrics(MathMetrics):
             if not valid_pairs:
                 majority_score = 0.0
             else:
-                answer_counts = Counter(valid_pairs)
-                top_count = answer_counts.most_common(1)[0][1]
-                top_pairs = [(ans, sc) for (ans, sc), cnt in answer_counts.items() if cnt == top_count]
-                majority_score = sum(sc for _, sc in top_pairs) / len(top_pairs)
+                # Vote on the answer alone: the same answer can carry different scores
+                # across attempts, and those are repeated votes for one answer.
+                answer_scores = defaultdict(list)
+                for ans, sc in valid_pairs:
+                    answer_scores[ans].append(sc)
+                top_count = max(len(scores) for scores in answer_scores.values())
+                top_answers = [ans for ans, scores in answer_scores.items() if len(scores) == top_count]
+                # Average the scores within an answer first, then average across the
+                # most common answers as before.
+                majority_score = sum(sum(answer_scores[ans]) / len(answer_scores[ans]) for ans in top_answers)
+                majority_score /= len(top_answers)
             self.weighted_sums[f"majority@{k}"][score_method] += sample_weight * majority_score
 
     def update(self, predictions: list[dict]) -> None:

--- a/tests/test_base_metrics.py
+++ b/tests/test_base_metrics.py
@@ -192,3 +192,39 @@ def test_base_metrics_update(predictions, expected_all_scores):
     metrics = MockMetrics()
     metrics.update(predictions)
     assert metrics.all_scores == expected_all_scores
+
+
+@pytest.mark.parametrize(
+    "answers,verdicts,expected",
+    [
+        # The issue's example: a non-deterministic judge scores the same answer both
+        # ways. "42" has three votes to "43"'s two and wins outright, so only its
+        # three verdicts decide the score.
+        (["42", "42", "42", "43", "43"], [True, False, True, False, False], 2 / 3),
+        (["7", "7", "7"], [True, True, False], 2 / 3),
+        # The judge called the winning answer wrong more often than right.
+        (["a", "a", "a"], [True, False, False], 1 / 3),
+        # A deterministic judge is unaffected.
+        (["42", "42", "43"], [True, True, False], 1.0),
+        (["9", "9", "9"], [False, False, False], 0.0),
+        # Genuinely tied distinct answers still average across the tie.
+        (["a", "b"], [True, False], 0.5),
+        # Tie where one side is itself split: 0.5 for that answer, 1.0 for the clean one.
+        (["a", "a", "b", "b"], [True, False, True, True], 0.75),
+    ],
+)
+def test_majority_at_k_votes_on_the_answer(answers, verdicts, expected):
+    """Duplicate answers are one candidate, however the judge scored them (#1257)."""
+    metrics = MockMetrics(compute_no_answer=False)
+    predictions = [{"is_correct": v} for v in verdicts]
+    metrics._compute_majority_at_k(predictions=predictions, predicted_answers=answers)
+    k = len(answers)
+    assert metrics.eval_dict[f"majority@{k}"]["correct"] == pytest.approx(expected)
+
+
+def test_majority_at_k_ignores_none_answers():
+    """None answers are dropped before voting."""
+    metrics = MockMetrics(compute_no_answer=False)
+    predictions = [{"is_correct": v} for v in [True, False, True]]
+    metrics._compute_majority_at_k(predictions=predictions, predicted_answers=["5", None, "5"])
+    assert metrics.eval_dict["majority@3"]["correct"] == pytest.approx(1.0)

--- a/tests/test_math_metrics.py
+++ b/tests/test_math_metrics.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_skills.evaluation.metrics.math_metrics import MathMetrics
+
+
+def _prediction(answer, is_correct, reward_score):
+    return {
+        "predicted_answer": answer,
+        "judgement": f"Judgement: {'Yes' if is_correct else 'No'}",
+        "reward_model_score": reward_score,
+    }
+
+
+@pytest.mark.parametrize(
+    "verdicts,expected",
+    [
+        # The reward winner is "42" either way, so the order the judge disagreed in
+        # must not change its score (#1257).
+        ([True, False], 0.5),
+        ([False, True], 0.5),
+        ([True, True], 1.0),
+        ([False, False], 0.0),
+    ],
+)
+def test_reward_at_k_averages_verdicts_for_the_winning_answer(verdicts, expected):
+    """Repeated occurrences of one answer are pooled instead of last-write-wins."""
+    metrics = MathMetrics(compute_no_answer=False)
+    predictions = [_prediction("42", verdict, reward_score=1.0) for verdict in verdicts]
+    metrics._compute_reward_at_k(predictions)
+    assert metrics.eval_dict["rm_majority@2"]["judge_correct"] == pytest.approx(expected)
+
+
+def test_reward_at_k_picks_the_highest_cumulative_reward_answer():
+    """Answer grouping does not disturb which answer wins on reward."""
+    metrics = MathMetrics(compute_no_answer=False)
+    predictions = [
+        _prediction("42", is_correct=True, reward_score=0.6),
+        _prediction("42", is_correct=True, reward_score=0.6),
+        _prediction("43", is_correct=False, reward_score=1.0),
+    ]
+    metrics._compute_reward_at_k(predictions)
+    # "42" has 1.2 cumulative reward against "43"'s 1.0, and both its verdicts agree.
+    assert metrics.eval_dict["rm_majority@3"]["judge_correct"] == pytest.approx(1.0)
+    # rm_best@k still follows the single highest-scoring generation, which is "43".
+    assert metrics.eval_dict["rm_best@3"]["judge_correct"] == pytest.approx(0.0)


### PR DESCRIPTION
Fixes #1257.

Both of the things @sgunasekar described reproduce on main (e06c9b9), and the same two patterns are copy-pasted into two more files, so this does all four sites.

`_compute_majority_at_k` counted `(answer, score)` tuples, so a judge that scored `"42"` both ways turned one candidate into two. `_compute_reward_at_k` kept correctness in a plain dict assignment, so the last generation to mention the reward-winning answer set its verdict.

Both now group by the answer string, then average the winner's verdicts. I went with the mean rather than max/majority because line 279 already averaged across genuinely tied distinct answers and that looked deliberate, so letting the same averaging run over the winner's verdicts is the smaller change. Happy to switch it to max or majority if you'd rather, it's one line.

```
case                        before   after
issue example                0.500   0.667
judge flips once             1.000   0.667
winner mostly wrong          0.000   0.333
deterministic (control)      1.000   1.000
all wrong (control)          0.000   0.000
real tie (control)           0.500   0.500
```

Controls don't move, so `symbolic_correct` and anything else deterministic is unaffected. Anyone judging with a non-deterministic LLM will see maj@k and rm_majority@k shift though, which is the point but worth knowing before it lands.

Files touched:
- `base.py` `_compute_majority_at_k`
- `math_metrics.py` `_compute_reward_at_k`
- `omni_metrics.py` `_compute_reward_at_k`, same last-write-wins, looks copied
- `weighted_math_metrics.py` `_update_majority_at_k`, same Counter over pairs

Tests: extended `tests/test_base_metrics.py` with the issue's example and the tie cases, and added `tests/test_math_metrics.py` for the reward path, which didn't have unit coverage before.

One note on #1517, which is linked to close this issue: it adds a new `fix.py` at the repo root and doesn't touch any of the four files above, so I don't think it closes anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved majority-vote scoring by grouping results by answer rather than answer-and-score combinations.
  * Averaged all verdicts for repeated answers, preventing results from depending on generation order.
  * Handled tied top answers deterministically and ignored missing answers.
  * Improved reward-at-k calculations across math and general evaluation metrics.

* **Tests**
  * Added coverage for repeated answers, tied results, ordering independence, missing answers, and reward selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->