### PR TITLE
docs: point Papers & Releases link at docs/releases/index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ commands and their options.
 
 You can find more examples of how to use Nemo-Skills in the [tutorials](https://nvidia-nemo.github.io/Skills/tutorials) page.
 
-We've built and released many popular models and datasets using Nemo-Skills. See all of them in the [Papers & Releases](./releases/index.md) documentation.
+We've built and released many popular models and datasets using Nemo-Skills. See all of them in the [Papers & Releases](./docs/releases/index.md) documentation.
 
 You can find the full documentation [here](https://nvidia-nemo.github.io/Skills/).
 


### PR DESCRIPTION
`README.md` links Papers & Releases to `./releases/index.md`, which does not exist. The page lives at `docs/releases/index.md`, so the link 404s from the repo front page.

```
gh api repos/NVIDIA-NeMo/Skills/contents/releases/index.md       -> 404
gh api repos/NVIDIA-NeMo/Skills/contents/docs/releases/index.md  -> exists
```

One-line fix adding the missing `docs/` prefix. No other links in the README were affected: I checked the rest against the repo and they resolve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Papers & Releases” link in the Getting Started section to point to the correct releases documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->