### PR TITLE
MMLU ProX bugfix

### DIFF
--- a/nemo_skills/prompt/config/multilingual/mmlu-prox.yaml
+++ b/nemo_skills/prompt/config/multilingual/mmlu-prox.yaml
@@ -1,7 +1,7 @@
 few_shot_examples:
   prefix: ""
-  template: "{problem}{solution}\n\n"
+  template: "{question}{solution}\n\n"
   suffix: ""
 
 user: |-
-  {description}{examples}{problem}
+  {description}{examples}{question}


### PR DESCRIPTION
MMLU-ProX prompt did not contain options to choose from for MQA. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the multilingual MMLU-Pro prompt to correctly reference the question content in few-shot examples and user prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->