### PR TITLE
Prefer explicit "Answer: X" line over letters inside boxed expressions in MCQ eval

### DIFF
--- a/nemo_skills/evaluation/evaluator/mcq.py
+++ b/nemo_skills/evaluation/evaluator/mcq.py
@@ -86,19 +86,21 @@ def eval_mcq(cfg):
             extracted_answer = normalize_extracted_answer(extracted_answer)
 
         parsed_letter = None
-        if extracted_answer is not None:
-            if len(extracted_answer) == 1:
-                parsed_letter = extracted_answer.upper()
-            elif len(extracted_answer) > 1:
-                # try to extract the letter from extracted answer, useful to match <A>, {A}, *A*, etc.
-                match = re.findall(r"\b[A-Z]\b(?!.*\b[A-Z]\b)", extracted_answer, re.DOTALL)
-                if len(match) > 0:
-                    parsed_letter = match[-1].strip().upper()
+        if extracted_answer is not None and len(extracted_answer) == 1:
+            parsed_letter = extracted_answer.upper()
 
         # adapted from https://artificialanalysis.ai/methodology/intelligence-benchmarking#intelligence-index-evaluation-suite-overview
+        # An explicit "Answer: X" line takes precedence over a letter scavenged from a longer extracted
+        # expression, e.g. \boxed{\Delta E} in the reasoning would otherwise be parsed as "E"
         if parsed_letter is None:
             match = re.findall(r"(?i)[\*\_]{0,2}Answer[\*\_]{0,2}\s*:[\s\*\_]{0,2}\s*([A-Z])(?![a-zA-Z0-9])", text)
             if match:
+                parsed_letter = match[-1].strip().upper()
+
+        if parsed_letter is None and extracted_answer is not None and len(extracted_answer) > 1:
+            # try to extract the letter from extracted answer, useful to match <A>, {A}, *A*, etc.
+            match = re.findall(r"\b[A-Z]\b(?!.*\b[A-Z]\b)", extracted_answer, re.DOTALL)
+            if len(match) > 0:
                 parsed_letter = match[-1].strip().upper()
 
         LOG.info(

--- a/tests/test_mcq_evaluator.py
+++ b/tests/test_mcq_evaluator.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from nemo_skills.evaluation.evaluator.mcq import eval_mcq
+
+
+def _predict(tmp_path, generation, **sample_overrides):
+    input_file = tmp_path / "output.jsonl"
+    sample = {"generation": generation, "expected_answer": "D", **sample_overrides}
+    input_file.write_text(json.dumps(sample) + "\n", encoding="utf-8")
+    eval_mcq({"input_file": str(input_file)})
+    return json.loads(input_file.read_text(encoding="utf-8"))["predicted_answer"]
+
+
+@pytest.mark.parametrize(
+    "generation, expected",
+    [
+        # explicit "Answer: X" line must win over a letter inside a boxed math expression (issue #1511)
+        (
+            "The adiabatic regime requires\n\n\\boxed{\\langle H\\rangle \\ll \\Delta E}\n\nso the correct statement is D.\n\n**Answer: D**",
+            "D",
+        ),
+        # a boxed single letter is still used as is
+        ("Reasoning...\n\n\\boxed{D}", "D"),
+        ("Reasoning...\n\nAnswer: \\boxed{B}", "B"),
+        # multi-character boxed content still falls back to the wrapped-letter heuristic when there is no explicit answer line
+        ("Reasoning...\n\n\\boxed{(C)}", "C"),
+        ("Reasoning...\n\n\\boxed{\\text{A}}", "A"),
+        # explicit answer line with no boxed expression at all
+        ("Reasoning...\n\nAnswer: B", "B"),
+        # nothing parseable
+        ("I am not sure.", None),
+    ],
+)
+def test_extract_letter(tmp_path, generation, expected):
+    assert _predict(tmp_path, generation) == expected


### PR DESCRIPTION
## What was wrong

`ns_gpqa` (and every other `eval_type=multichoice` benchmark) can score a correct answer as wrong when the reasoning contains a `\boxed{}` math expression. For the sample in #1511 the generation ends with `**Answer: D**` but also contains `\boxed{\langle H\rangle \ll \Delta E}`; the evaluator produced

```
predicted_answer: E   expected_answer: D   symbolic_correct: False
```

## Root cause

In `nemo_skills/evaluation/evaluator/mcq.py::extract_letter`, the boxed/regex extraction runs first (`relaxed=True` by default). When the extracted string is longer than one character, the code immediately applies the "last isolated capital letter" heuristic (`\b[A-Z]\b(?!.*\b[A-Z]\b)`) meant for wrapped letters like `<A>`, `{A}`, `*A*`. On `\langle H\rangle \ll \Delta E` that returns `E`. Because a letter was found, the explicit `Answer: X` regex (the format the `eval/aai/mcq-*` prompts ask for as the last line) is never consulted.

## The fix

Reorder the fallbacks in `extract_letter`:

1. single-letter extraction (e.g. `\boxed{D}`, `Answer: \boxed{D}`) is used as is, unchanged;
2. otherwise, an explicit `Answer: X` line in the generation takes precedence;
3. the wrapped-letter heuristic on a multi-character extraction only runs when no explicit answer line exists.

Behaviour is unchanged for single-letter boxes, for multi-character boxes without an explicit answer line (`\boxed{(C)}`, `\boxed{\text{A}}` still yield `C` / `A`), and for outputs with no boxed expression. The only outputs that change are those with a multi-character boxed/regex match *and* an explicit `Answer: X` line, where the explicit line now wins.

## Verification

Regression test added in `tests/test_mcq_evaluator.py` (parametrised over the issue case plus the unchanged cases above).

```
python -m pytest -s tests/test_mcq_evaluator.py
# before fix: 1 failed, 6 passed  (AssertionError: assert 'E' == 'D')
# after fix:  7 passed

python -m pytest -s tests/test_mcq_evaluator.py tests/test_math_equal.py tests/test_metrics.py
# 39 passed, 3 failed -- the 3 test_metrics failures are FileNotFoundError: 'ns' (CLI not on PATH in my env) and fail identically on clean main

ruff check / ruff format --check on the two changed files: clean
```

CPU only, no GPU used; the evaluator is pure Python.

Fixes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiple-choice answer extraction to prioritize clear single-letter answers and explicit answer lines, including answers surrounded by formatting.
  * Reduced incorrect answer selection when responses contain competing mathematical or textual content.

* **Tests**
  * Added coverage for formatted answers, explicit answer lines, wrapped letters, and unparseable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->