### PR TITLE
Restore boxed-first default for relaxed answer extraction, add opt-in regex_first

### DIFF
--- a/nemo_skills/evaluation/evaluator/math.py
+++ b/nemo_skills/evaluation/evaluator/math.py
@@ -38,8 +38,10 @@ class MathEvaluatorConfig(BaseEvaluatorConfig):
     extract_from_boxed: bool = True
     # only used if extract_from_boxed is False
     extract_regex: str = r"The final answer is (.+)$"
-    # if True: try regex first, then boxed (regardless of extract_from_boxed)
+    # if True: try both boxed and regex (regardless of extract_from_boxed), boxed first
     relaxed_extraction: bool = False
+    # only used if relaxed_extraction is True: try regex first, then boxed
+    regex_first: bool = False
     take_modulo: int | None = None  # will take modulo of the gt and predicted answers if not None
 
 
@@ -67,6 +69,7 @@ class MathEvaluator(BaseEvaluator):
                 extract_from_boxed=self.eval_config.extract_from_boxed,
                 extract_regex=self.eval_config.extract_regex,
                 relaxed=self.eval_config.relaxed_extraction,
+                regex_first=self.eval_config.regex_first,
             )
         else:
             if "predicted_answer" not in data_point:

--- a/nemo_skills/evaluation/evaluator/mcq.py
+++ b/nemo_skills/evaluation/evaluator/mcq.py
@@ -52,11 +52,14 @@ class MCQEvaluatorConfig(BaseEvaluatorConfig):
     # only used if extract_from_boxed is False
     extract_regex: str | list[str] = r"The final answer is (.+)$"
     # if relaxed is True:
-    #   extract from regex FIRST, if not found, extract from boxed
+    #   extract from boxed FIRST, if not found, extract from regex
+    #   (or regex FIRST, then boxed, if regex_first is True)
     # if relaxed is False:
     #   if extract_from_boxed is True -> extract from boxed{} ONLY
     #   else extract from regex ONLY
     relaxed: bool = True
+    # only used if relaxed is True
+    regex_first: bool = False
 
 
 def eval_mcq(cfg):
@@ -67,19 +70,28 @@ def eval_mcq(cfg):
         extract_from_boxed: bool = True,
         extract_regex: str | list[str] = r"The final answer is (.+)$",
         relaxed=False,
+        regex_first=False,
     ):
         # extract prediction from boxed{} or regex
         extracted_answer = None
         if isinstance(extract_regex, list):
             for regex in extract_regex:
                 extracted_answer = extract_answer(
-                    text, extract_from_boxed=extract_from_boxed, extract_regex=regex, relaxed=relaxed
+                    text,
+                    extract_from_boxed=extract_from_boxed,
+                    extract_regex=regex,
+                    relaxed=relaxed,
+                    regex_first=regex_first,
                 )
                 if extracted_answer is not None:
                     break
         else:
             extracted_answer = extract_answer(
-                text, extract_from_boxed=extract_from_boxed, extract_regex=extract_regex, relaxed=relaxed
+                text,
+                extract_from_boxed=extract_from_boxed,
+                extract_regex=extract_regex,
+                relaxed=relaxed,
+                regex_first=regex_first,
             )
 
         if extracted_answer is not None:
@@ -103,7 +115,8 @@ def eval_mcq(cfg):
 
         LOG.info(
             f"Final parsed letter: {parsed_letter}, extract_from_boxed: {extract_from_boxed}, "
-            f"extract_regex: {extract_regex}, extracted_answer: {extracted_answer}, relaxed: {relaxed}"
+            f"extract_regex: {extract_regex}, extracted_answer: {extracted_answer}, relaxed: {relaxed}, "
+            f"regex_first: {regex_first}"
         )
 
         return parsed_letter
@@ -117,11 +130,13 @@ def eval_mcq(cfg):
             extract_from_boxed = sample.get("extract_from_boxed", eval_config.extract_from_boxed)
             extract_regex = sample.get("extract_regex", eval_config.extract_regex)
             relaxed = sample.get("relaxed", eval_config.relaxed)
+            regex_first = sample.get("regex_first", eval_config.regex_first)
             sample["predicted_answer"] = extract_letter(
                 sample["generation"],
                 extract_from_boxed=extract_from_boxed,
                 extract_regex=extract_regex,
                 relaxed=relaxed,
+                regex_first=regex_first,
             )
             sample["symbolic_correct"] = sample["predicted_answer"] == sample["expected_answer"]
             fout.write(json.dumps(sample) + "\n")

--- a/nemo_skills/evaluation/math_grader.py
+++ b/nemo_skills/evaluation/math_grader.py
@@ -100,14 +100,20 @@ def math_equal(gt_answer, predicted_answer, take_modulo: int | None = None, **kw
 
 
 def extract_answer(
-    string: str, extract_from_boxed: bool = True, extract_regex: str = r"The final answer is (.+)$", relaxed=False
+    string: str,
+    extract_from_boxed: bool = True,
+    extract_regex: str = r"The final answer is (.+)$",
+    relaxed=False,
+    regex_first: bool = False,
 ):
     """Extract Answer String from \\boxed expression or based on regex
-    If relaxed=True: try both methods, regex first.
+    If relaxed=True: try both methods, boxed first (or regex first if regex_first=True).
     If relaxed=False: use only one method based on extract_from_boxed flag.
     """
     if relaxed:
-        return search_regex(string, extract_regex) or search_boxed(string)
+        if regex_first:
+            return search_regex(string, extract_regex) or search_boxed(string)
+        return search_boxed(string) or search_regex(string, extract_regex)
 
     if extract_from_boxed:
         return search_boxed(string)

--- a/nemo_skills/pipeline/robust_eval.py
+++ b/nemo_skills/pipeline/robust_eval.py
@@ -120,6 +120,8 @@ def robust_eval(
                     # Quote properly for it to be correct passed to ns eval in terminal
                     shell_safe_arg = shlex.quote(shlex.quote(hydra_arg))
                     prompt_context.args.append(shell_safe_arg)
+                    # prompts with a custom answer format should be matched by their regex before falling back to boxed
+                    prompt_context.args.append("++eval_config.regex_first=True")
 
                 prompt_context.args.append(f"++prompt_config={prompt.prompt_config}")
 

--- a/tests/test_answer_extraction.py
+++ b/tests/test_answer_extraction.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from nemo_skills.evaluation.evaluator.mcq import eval_mcq
+from nemo_skills.evaluation.math_grader import extract_answer
+
+BOTH = "Some reasoning with \\boxed{A} in the middle.\n\nThe final answer is B"
+REGEX_ONLY = "Some reasoning.\n\nThe final answer is B"
+BOXED_ONLY = "Some reasoning.\n\n\\boxed{A}"
+
+
+def test_strict_extraction_uses_a_single_method():
+    assert extract_answer(BOTH, extract_from_boxed=True) == "A"
+    assert extract_answer(BOTH, extract_from_boxed=False) == "B"
+    assert extract_answer(REGEX_ONLY, extract_from_boxed=True) is None
+    assert extract_answer(BOXED_ONLY, extract_from_boxed=False) is None
+
+
+def test_relaxed_extraction_prefers_boxed_by_default():
+    assert extract_answer(BOTH, relaxed=True) == "A"
+    assert extract_answer(REGEX_ONLY, relaxed=True) == "B"
+    assert extract_answer(BOXED_ONLY, relaxed=True) == "A"
+
+
+def test_relaxed_extraction_regex_first_is_opt_in():
+    assert extract_answer(BOTH, relaxed=True, regex_first=True) == "B"
+    assert extract_answer(REGEX_ONLY, relaxed=True, regex_first=True) == "B"
+    assert extract_answer(BOXED_ONLY, relaxed=True, regex_first=True) == "A"
+    # regex_first has no effect in strict mode
+    assert extract_answer(BOTH, extract_from_boxed=True, regex_first=True) == "A"
+
+
+def _mcq_predict(tmp_path, generation, eval_config=None, **sample_overrides):
+    input_file = tmp_path / "output.jsonl"
+    sample = {"generation": generation, "expected_answer": "A", **sample_overrides}
+    input_file.write_text(json.dumps(sample) + "\n", encoding="utf-8")
+    eval_mcq({"input_file": str(input_file), **(eval_config or {})})
+    return json.loads(input_file.read_text(encoding="utf-8"))["predicted_answer"]
+
+
+def test_mcq_relaxed_order(tmp_path):
+    generation = "Reasoning with \\boxed{A}.\n\nThe correct answer choice is: B"
+    regex = r"(?i)The correct answer choice is\:*\**\s*\**([A-Za-z])"
+    # default: boxed first
+    assert _mcq_predict(tmp_path, generation, {"extract_regex": regex}) == "A"
+    # opt-in via eval config
+    assert _mcq_predict(tmp_path, generation, {"extract_regex": regex, "regex_first": True}) == "B"
+    # opt-in via per-sample override
+    assert _mcq_predict(tmp_path, generation, {"extract_regex": regex}, regex_first=True) == "B"


### PR DESCRIPTION
## What was wrong

#1079 changed `extract_answer(..., relaxed=True)` in `nemo_skills/evaluation/math_grader.py` from "boxed first, then regex" to "regex first, then boxed" so that the robustness prompts with a custom answer format could be matched by their regex. As flagged in #1084, that changed the default for every relaxed caller, not only the robustness pipeline:

- `eval_type=multichoice` uses `relaxed=True` by default (`MCQEvaluatorConfig.relaxed`)
- `MathEvaluatorConfig.relaxed_extraction`

Concretely, on `main` a generation containing both `\boxed{A}` and a trailing `The final answer is B` extracts `B`; before #1079 it extracted `A`.

## The fix

Restore the original default and make the regex-first order an explicit flag, as requested in #1084:

- `extract_answer()` gains `regex_first: bool = False`; it is only consulted when `relaxed=True` (strict mode is untouched).
- `MCQEvaluatorConfig` and `MathEvaluatorConfig` expose `regex_first: bool = False`. The MCQ evaluator also honours a per-sample `regex_first` key, mirroring how `relaxed` / `extract_regex` / `extract_from_boxed` can already be overridden per sample.
- `ns robust_eval` appends `++eval_config.regex_first=True` for prompts that set a custom `extract_regex` in `prompt_set_config.yaml`, so the robustness pipeline keeps exactly the behaviour #1079 introduced for it. Prompts without a custom regex (`aai_*`, `boxed_*`, all math and code prompts) were never affected by the order.

Default MCQ evals (`eval/aai/mcq-*` prompts with the default `The final answer is (.+)$` regex) are unaffected either way, as #1079 noted.

## Verification

New `tests/test_answer_extraction.py` covers strict mode, relaxed default order, the `regex_first` opt-in, and the MCQ evaluator (config-level and per-sample override).

```
python -m pytest -s tests/test_answer_extraction.py
# on main:      3 failed, 1 passed  (relaxed default returns 'B'; regex_first kwarg missing)
# with this PR: 4 passed

python -m pytest -s tests/test_answer_extraction.py tests/test_math_equal.py
# 36 passed

ruff check / ruff format --check on the 5 changed files: clean
```

`tests/test_eval.py` (pipeline) could not be collected in my environment because the orchestration extras are not installed there; there is no existing test that inspects the arguments `robust_eval` builds, so that two-line change was verified by reading only.

CPU only, no GPU used.

Fixes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable answer-extraction ordering for math and multiple-choice evaluations.
  * Boxed answers are now prioritized by default in relaxed math extraction, with an option to prioritize regular-expression matches instead.
  * Multiple-choice evaluations support the same ordering configuration at both evaluator and individual-sample levels.
  * Custom answer-format regular expressions now take precedence when specified in robust evaluation workflows.

* **Tests**
  * Expanded coverage for strict, relaxed, boxed, regex-based, and multiple-choice answer extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->