### PR TITLE
Apply BFCL Java/JavaScript preprocessing to simple_java and simple_javascript categories

### DIFF
--- a/nemo_skills/dataset/bfcl_v3/utils.py
+++ b/nemo_skills/dataset/bfcl_v3/utils.py
@@ -34,12 +34,13 @@ import json
 import re
 
 from bfcl_eval.constants.type_mappings import GORILLA_TO_OPENAPI
+from bfcl_eval.utils import is_java, is_js
 
 
 def _get_language_specific_hint(test_category):
-    if test_category == "java":
+    if is_java(test_category):
         return " Note that the provided function is in Java 8 SDK syntax."
-    elif test_category == "javascript":
+    elif is_js(test_category):
         return " Note that the provided function is in JavaScript syntax."
     else:
         return " Note that the provided function is in Python 3 syntax."
@@ -55,7 +56,7 @@ def func_doc_language_specific_pre_processing(function, test_category):
         item["description"] = item["description"] + _get_language_specific_hint(test_category)
         # Process the parameters
         properties = item["parameters"]["properties"]
-        if test_category == "java":
+        if is_java(test_category):
             for key, value in properties.items():
                 if value["type"] == "any":
                     properties[key]["description"] += (
@@ -71,7 +72,7 @@ def func_doc_language_specific_pre_processing(function, test_category):
 
                 value["type"] = "string"
 
-        elif test_category == "javascript":
+        elif is_js(test_category):
             for key, value in properties.items():
                 if value["type"] == "any":
                     properties[key]["description"] += (

--- a/tests/test_bfcl_preprocessing.py
+++ b/tests/test_bfcl_preprocessing.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+
+import pytest
+
+pytest.importorskip("bfcl_eval")
+
+from nemo_skills.dataset.bfcl_v3.utils import func_doc_language_specific_pre_processing  # noqa: E402
+
+JAVA_FUNCTION = [
+    {
+        "name": "MathUtils.sumList",
+        "description": "Sum a list of integers.",
+        "parameters": {
+            "type": "dict",
+            "properties": {
+                "values": {"type": "ArrayList", "items": {"type": "Integer"}, "description": "Values to add."},
+                "scale": {"type": "int", "description": "Scale factor."},
+            },
+            "required": ["values"],
+        },
+    }
+]
+
+JS_FUNCTION = [
+    {
+        "name": "sumList",
+        "description": "Sum a list of numbers.",
+        "parameters": {
+            "type": "dict",
+            "properties": {
+                "values": {"type": "array", "items": {"type": "number"}, "description": "Values to add."},
+                "options": {
+                    "type": "dict",
+                    "properties": {"round": {"type": "Boolean"}},
+                    "description": "Options.",
+                },
+            },
+            "required": ["values"],
+        },
+    }
+]
+
+
+@pytest.mark.parametrize("test_category", ["java", "simple_java"])
+def test_java_categories_are_stringified(test_category):
+    processed = func_doc_language_specific_pre_processing(copy.deepcopy(JAVA_FUNCTION), test_category)
+    props = processed[0]["parameters"]["properties"]
+    assert processed[0]["description"].endswith("Note that the provided function is in Java 8 SDK syntax.")
+    assert props["values"]["type"] == "string"
+    assert "items" not in props["values"]
+    assert "Integer" in props["values"]["description"]
+    assert props["scale"]["type"] == "string"
+
+
+@pytest.mark.parametrize("test_category", ["javascript", "simple_javascript"])
+def test_javascript_categories_are_stringified(test_category):
+    processed = func_doc_language_specific_pre_processing(copy.deepcopy(JS_FUNCTION), test_category)
+    props = processed[0]["parameters"]["properties"]
+    assert processed[0]["description"].endswith("Note that the provided function is in JavaScript syntax.")
+    assert props["values"]["type"] == "string"
+    assert "items" not in props["values"]
+    assert props["options"]["type"] == "string"
+    assert "properties" not in props["options"]
+
+
+@pytest.mark.parametrize("test_category", ["simple_python", "simple", "irrelevance", "multi_turn_base"])
+def test_other_categories_are_left_unchanged(test_category):
+    processed = func_doc_language_specific_pre_processing(copy.deepcopy(JAVA_FUNCTION), test_category)
+    props = processed[0]["parameters"]["properties"]
+    assert processed[0]["description"].endswith("Note that the provided function is in Python 3 syntax.")
+    assert props["values"]["type"] == "ArrayList"
+    assert props["values"]["items"] == {"type": "Integer"}


### PR DESCRIPTION
## What was wrong

#1510 reports that `nemo_skills`' BFCL preprocessing leaves Java/JavaScript parameter types unchanged, while upstream BFCL converts them to string representation for the `simple_java` / `simple_javascript` splits, so calls that BFCL's checker would accept are marked `is_correct: false` here.

The conversion code is present in `nemo_skills/dataset/bfcl_v3/utils.py`, but it is gated on an exact category match:

```python
if test_category == "java":
...
elif test_category == "javascript":
```

The pinned upstream commit (`86d0374`, `BFCL_v4` data) only ships `BFCL_v4_simple_java.json` and `BFCL_v4_simple_javascript.json`, and `nemo_skills/dataset/bfcl_v3/constants.py` lists `simple_java` / `simple_javascript` as the scoring categories. Neither equals `"java"` / `"javascript"`, so for the splits actually in use:

- `_get_language_specific_hint` appends the *Python 3* hint to every Java/JS function description, and
- `func_doc_language_specific_pre_processing` skips the string-type conversion (and the `items` / `properties` flattening) entirely.

This applies both at data preparation (`prepare.py`) and at inference time (`nemo_skills/inference/eval/bfcl.py` derives `test_category` from the sample id, e.g. `simple_java_12` -> `simple_java`).

Upstream's own implementation dispatches on substring predicates (`bfcl_eval/utils.py`):

```python
def is_java(test_category):
    return "java" in test_category and not is_js(test_category)

def is_js(test_category):
    return "javascript" in test_category
```

## The fix

Import `is_java` / `is_js` from `bfcl_eval.utils` (the module `prepare.py` already imports its other category predicates from) and dispatch on them in both functions. This matches upstream and covers the legacy `java` / `javascript` names as well as `simple_java` / `simple_javascript`. No change for any other category.

## Verification

New `tests/test_bfcl_preprocessing.py` (skipped if `bfcl_eval` is not installed, like the other runtime-installed benchmark deps):

```
python -m pytest -s tests/test_bfcl_preprocessing.py
# on main:      2 failed, 6 passed  (simple_java / simple_javascript not stringified)
# with this PR: 8 passed

ruff check / ruff format --check on the two changed files: clean
```

`bfcl_eval` was installed from the pinned commit for the test run. CPU only, no GPU used.

Fixes #1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection during function-document preprocessing for Java and JavaScript categories.
  * Ensured parameter schemas are converted and nested fields handled correctly for JavaScript and Java, while preserving schemas for other categories.

* **Tests**
  * Added coverage for Java, JavaScript, and language-independent preprocessing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->